### PR TITLE
🐛 Fix redirect_to value

### DIFF
--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -39,9 +39,7 @@ const Login: NextPage = () => {
         console.error(res)
         return
       }
-      router.push({
-        pathname: Route.Routines,
-      })
+      alert("Look for your log in link in your inbox!")
     } catch (err) {
       console.error(err)
     }

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -25,7 +25,7 @@ const Login: NextPage = () => {
 
     try {
       const res = await fetch(
-        `${process.env.NEXT_PUBLIC_API_ROOT}/login?redirect_to=${window.location.host}`,
+        `${process.env.NEXT_PUBLIC_API_ROOT}/login?redirect_to=${window.location.origin}`,
         {
           method: 'POST',
           credentials: 'include',

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -20,7 +20,7 @@ const Signup: NextPage = () => {
 
     try {
       const res = await fetch(
-        `${process.env.NEXT_PUBLIC_API_ROOT}/signup?redirect_to=${window.location.host}`,
+        `${process.env.NEXT_PUBLIC_API_ROOT}/signup?redirect_to=${window.location.origin}`,
         {
           method: 'POST',
           credentials: 'include',


### PR DESCRIPTION
Previously, we weren't including the protocol leading to complaints from the browser. Setting the value to `window.location.origin` makes it so we navigate to the home page of whatever environment we are on.

Additionally, instead of redirecting to the Routines page after login, we're now showing an alert - mirroring the signup flow. Eventually, this should redirect to a nice page telling users to check their email. For now, `alert(...)`. 