### PR TITLE
New link behavior in Next.js 12.2

### DIFF
--- a/components/button.tsx
+++ b/components/button.tsx
@@ -29,13 +29,13 @@ export const Back = ({ href }: BackProps) => {
       whileTap="hover"
     >
       <div className="flex absolute w-12 h-12 items-center justify-center z-10">
-        <Link href={href}>
-          <a
-            className="w-12 h-12 flex items-center justify-center"
-            onDragStart={(e) => e.preventDefault()}
-          >
-            <ArrowLeftIcon className="w-6 h-6" />
-          </a>
+        <Link
+          href={href}
+          className="w-12 h-12 flex items-center justify-center"
+          onDragStart={(e) => e.preventDefault()}>
+
+          <ArrowLeftIcon className="w-6 h-6" />
+
         </Link>
       </div>
       <motion.svg className="absolute w-12 h-12 z-0" viewBox="-25 -25 400 400">
@@ -50,5 +50,5 @@ export const Back = ({ href }: BackProps) => {
         />
       </motion.svg>
     </motion.div>
-  )
+  );
 }

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,7 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
   reactStrictMode: true,
+  experimental: {
+    newNextLinkBehavior: true,
+  },
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,8 +15,8 @@ const Temp = () => (
       href={{
         pathname: Route.Login,
       }}
-    >
-      <a className="px-4 py-2 border border-gray-50 text-xl">Login</a>
+      className="px-4 py-2 border border-gray-50 text-xl">
+      Login
     </Link>
   </div>
 )

--- a/pages/routines/[routineId]/index.tsx
+++ b/pages/routines/[routineId]/index.tsx
@@ -28,8 +28,8 @@ const WorkoutItem = ({ id, name, routineId }: Workout) => (
           workoutId: id,
         },
       }}
-    >
-      <a className="block py-8">{name}</a>
+      className="block py-8">
+      {name}
     </Link>
   </li>
 )

--- a/pages/routines/[routineId]/workouts/[workoutId]/index.tsx
+++ b/pages/routines/[routineId]/workouts/[workoutId]/index.tsx
@@ -28,7 +28,7 @@ const ExerciseItem = ({ routineId, workoutId, id, name }: Exercise) => (
         },
       }}
     >
-      <a>{name}</a>
+      {name}
     </Link>
   </li>
 )

--- a/pages/routines/index.tsx
+++ b/pages/routines/index.tsx
@@ -27,8 +27,8 @@ const RoutineItem = ({ id, name }: Routine) => (
           routineId: id,
         },
       }}
-    >
-      <a className="block py-8">{name}</a>
+      className="block py-8">
+      {name}
     </Link>
   </li>
 )


### PR DESCRIPTION
> `next/link` no longer requires manually adding <a> as a child. You can
> now opt into this behavior in a backward-compatible way.

Ref https://github.com/vercel/next.js/pull/36436
