### PR TITLE
🚸 Allow Log creation via Exercise Log list

### DIFF
--- a/pages/exerciselogs/index.tsx
+++ b/pages/exerciselogs/index.tsx
@@ -131,6 +131,19 @@ const ExerciseLogsPage: NextPage<Props> = ({ exerciseLogs }: Props) => {
       <Header left={<Back href={Route.Home} />} right={<Menu />}>
         <PageTitle>Exercise Logs</PageTitle>
       </Header>
+      <button className="w-full border border-neutral-300">
+        <Link
+          href={{
+            pathname: Route.Exercises,
+            query: {
+              logMode: true,
+            },
+          }}
+          className="block py-8"
+        >
+          New Log
+        </Link>
+      </button>
       <ul className="divide-y">
         {exerciseLogs.map((el) => (
           <ExerciseLogItem


### PR DESCRIPTION
Initiating the log creation flow from the Exercise Log page adds a new query param `logMode` to the URL. In the Exercise page, we check for the presence of this param and when found, Exercise selection goes directly to the new log page for that exercise.

This reduces the number of clicks necessary to create a new Exercise Log.